### PR TITLE
Extract RowFilterGenerator + push-decoder module from opener.rs

### DIFF
--- a/datafusion/datasource-parquet/src/mod.rs
+++ b/datafusion/datasource-parquet/src/mod.rs
@@ -30,6 +30,7 @@ pub mod metadata;
 mod metrics;
 mod opener;
 mod page_filter;
+mod push_decoder;
 mod reader;
 mod row_filter;
 mod row_group_filter;

--- a/datafusion/datasource-parquet/src/opener.rs
+++ b/datafusion/datasource-parquet/src/opener.rs
@@ -19,17 +19,17 @@
 
 use crate::access_plan::PreparedAccessPlan;
 use crate::page_filter::PagePruningAccessPlanFilter;
-use crate::push_decoder::DecoderBuilderConfig;
+use crate::push_decoder::{DecoderBuilderConfig, PushDecoderStreamState};
 use crate::row_filter::{RowFilterGenerator, build_projection_read_plan};
 use crate::row_group_filter::{BloomFilterStatistics, RowGroupAccessPlanFilter};
 use crate::{
     ParquetAccessPlan, ParquetFileMetrics, ParquetFileReaderFactory,
     apply_file_schema_type_coercions, coerce_int96_to_resolution,
 };
-use arrow::array::{RecordBatch, RecordBatchOptions};
+use arrow::array::RecordBatch;
 use arrow::datatypes::DataType;
 use datafusion_datasource::morsel::{Morsel, MorselPlan, MorselPlanner, Morselizer};
-use datafusion_physical_expr::projection::{ProjectionExprs, Projector};
+use datafusion_physical_expr::projection::ProjectionExprs;
 use datafusion_physical_expr::utils::reassign_expr_columns;
 use datafusion_physical_expr_adapter::replace_columns_with_literals;
 use std::collections::{HashMap, VecDeque};
@@ -40,12 +40,10 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
-use arrow::datatypes::{Schema, SchemaRef, TimeUnit};
+use arrow::datatypes::{SchemaRef, TimeUnit};
 use datafusion_common::encryption::FileDecryptionProperties;
 use datafusion_common::stats::Precision;
-use datafusion_common::{
-    ColumnStatistics, DataFusionError, Result, ScalarValue, Statistics, exec_err,
-};
+use datafusion_common::{ColumnStatistics, Result, ScalarValue, Statistics, exec_err};
 use datafusion_datasource::{PartitionedFile, TableSchema};
 use datafusion_physical_expr::simplifier::PhysicalExprSimplifier;
 use datafusion_physical_expr_adapter::PhysicalExprAdapterFactory;
@@ -53,8 +51,8 @@ use datafusion_physical_expr_common::physical_expr::{
     PhysicalExpr, is_dynamic_physical_expr,
 };
 use datafusion_physical_plan::metrics::{
-    BaselineMetrics, Count, ExecutionPlanMetricsSet, Gauge, MetricBuilder,
-    MetricCategory, PruningMetrics,
+    BaselineMetrics, Count, ExecutionPlanMetricsSet, MetricBuilder, MetricCategory,
+    PruningMetrics,
 };
 use datafusion_pruning::{FilePruner, PruningPredicate, build_pruning_predicate};
 
@@ -66,13 +64,11 @@ use futures::{
     FutureExt, Stream, StreamExt, future::BoxFuture, ready, stream::BoxStream,
 };
 use log::debug;
-use parquet::DecodeResult;
 use parquet::arrow::ParquetRecordBatchStreamBuilder;
 use parquet::arrow::arrow_reader::metrics::ArrowReaderMetrics;
 use parquet::arrow::arrow_reader::{ArrowReaderMetadata, ArrowReaderOptions};
 use parquet::arrow::async_reader::AsyncFileReader;
 use parquet::arrow::parquet_column;
-use parquet::arrow::push_decoder::ParquetPushDecoder;
 use parquet::basic::Type;
 use parquet::bloom_filter::Sbbf;
 use parquet::file::metadata::{
@@ -1202,27 +1198,23 @@ impl RowGroupsPrunedParquetOpen {
         let output_schema = Arc::clone(&prepared.output_schema);
         let files_ranges_pruned_statistics =
             prepared.file_metrics.files_ranges_pruned_statistics.clone();
-        let stream = futures::stream::unfold(
-            PushDecoderStreamState {
-                decoder,
-                pending_decoders,
-                remaining_limit,
-                reader: prepared.async_file_reader,
-                projector,
-                output_schema,
-                replace_schema,
-                arrow_reader_metrics,
-                predicate_cache_inner_records,
-                predicate_cache_records,
-                baseline_metrics: prepared.baseline_metrics,
-            },
-            |state| async move { state.transition().await },
-        )
-        .fuse();
+        let stream = PushDecoderStreamState {
+            decoder,
+            pending_decoders,
+            remaining_limit,
+            reader: prepared.async_file_reader,
+            projector,
+            output_schema,
+            replace_schema,
+            arrow_reader_metrics,
+            predicate_cache_inner_records,
+            predicate_cache_records,
+            baseline_metrics: prepared.baseline_metrics,
+        }
+        .into_stream();
 
         // Wrap the stream so a dynamic filter can stop the file scan early.
         if let Some(file_pruner) = prepared.file_pruner {
-            let stream = stream.boxed();
             Ok(EarlyStoppingStream::new(
                 stream,
                 file_pruner,
@@ -1230,7 +1222,7 @@ impl RowGroupsPrunedParquetOpen {
             )
             .boxed())
         } else {
-            Ok(stream.boxed())
+            Ok(stream)
         }
     }
 }
@@ -1246,140 +1238,6 @@ fn prepare_access_plan(
         prepared_access_plan = prepared_access_plan.reverse(file_metadata)?;
     }
     Ok(prepared_access_plan)
-}
-
-/// State for a stream that decodes a single Parquet file using a push-based decoder.
-///
-/// The [`transition`](Self::transition) method drives the decoder in a loop: it requests
-/// byte ranges from the [`AsyncFileReader`], pushes the fetched data into the
-/// [`ParquetPushDecoder`], and yields projected [`RecordBatch`]es until the file is
-/// fully consumed.
-struct PushDecoderStreamState {
-    decoder: ParquetPushDecoder,
-    /// Additional decoders to process after the current one finishes.
-    /// Used when fully matched row groups split the scan into consecutive
-    /// runs with different filter configurations, maintaining original order.
-    pending_decoders: VecDeque<ParquetPushDecoder>,
-    /// Global remaining row limit across all decoder runs.
-    ///
-    /// Decoder-local limits are only safe for single-run scans. When the scan
-    /// is split across multiple decoders, the combined stream limit is enforced
-    /// here instead.
-    remaining_limit: Option<usize>,
-    reader: Box<dyn AsyncFileReader>,
-    projector: Projector,
-    output_schema: Arc<Schema>,
-    replace_schema: bool,
-    arrow_reader_metrics: ArrowReaderMetrics,
-    predicate_cache_inner_records: Gauge,
-    predicate_cache_records: Gauge,
-    baseline_metrics: BaselineMetrics,
-}
-
-impl PushDecoderStreamState {
-    /// Advances the decoder state machine until the next [`RecordBatch`] is
-    /// produced, the file is fully consumed, or an error occurs.
-    ///
-    /// On each iteration the decoder is polled via [`ParquetPushDecoder::try_decode`]:
-    /// - [`NeedsData`](DecodeResult::NeedsData) – the requested byte ranges are
-    ///   fetched from the [`AsyncFileReader`] and fed back into the decoder.
-    /// - [`Data`](DecodeResult::Data) – a decoded batch is projected and returned.
-    /// - [`Finished`](DecodeResult::Finished) – signals end-of-stream (`None`).
-    ///
-    /// Takes `self` by value (rather than `&mut self`) so the generated future
-    /// owns the state directly. This avoids a Stacked Borrows violation under
-    /// miri where `&mut self` creates a single opaque borrow that conflicts
-    /// with `unfold`'s ownership across yield points.
-    async fn transition(mut self) -> Option<(Result<RecordBatch>, Self)> {
-        loop {
-            if self.remaining_limit == Some(0) {
-                return None;
-            }
-            match self.decoder.try_decode() {
-                Ok(DecodeResult::NeedsData(ranges)) => {
-                    let data = self
-                        .reader
-                        .get_byte_ranges(ranges.clone())
-                        .await
-                        .map_err(DataFusionError::from);
-                    match data {
-                        Ok(data) => {
-                            if let Err(e) = self.decoder.push_ranges(ranges, data) {
-                                return Some((Err(DataFusionError::from(e)), self));
-                            }
-                        }
-                        Err(e) => return Some((Err(e), self)),
-                    }
-                }
-                Ok(DecodeResult::Data(batch)) => {
-                    let batch = if let Some(remaining_limit) = self.remaining_limit {
-                        if batch.num_rows() > remaining_limit {
-                            self.remaining_limit = Some(0);
-                            batch.slice(0, remaining_limit)
-                        } else {
-                            self.remaining_limit =
-                                Some(remaining_limit - batch.num_rows());
-                            batch
-                        }
-                    } else {
-                        batch
-                    };
-                    let mut timer = self.baseline_metrics.elapsed_compute().timer();
-                    self.copy_arrow_reader_metrics();
-                    let result = self.project_batch(&batch);
-                    timer.stop();
-                    // Release the borrow on baseline_metrics before moving self
-                    drop(timer);
-                    return Some((result, self));
-                }
-                Ok(DecodeResult::Finished) => {
-                    // If there are pending decoders (e.g. for consecutive runs
-                    // with different filter configurations), switch to the next.
-                    if let Some(next) = self.pending_decoders.pop_front() {
-                        self.decoder = next;
-                        continue;
-                    }
-                    return None;
-                }
-                Err(e) => {
-                    return Some((Err(DataFusionError::from(e)), self));
-                }
-            }
-        }
-    }
-
-    /// Copies metrics from ArrowReaderMetrics (the metrics collected by the
-    /// arrow-rs parquet reader) to the parquet file metrics for DataFusion
-    fn copy_arrow_reader_metrics(&self) {
-        if let Some(v) = self.arrow_reader_metrics.records_read_from_inner() {
-            self.predicate_cache_inner_records.set(v);
-        }
-        if let Some(v) = self.arrow_reader_metrics.records_read_from_cache() {
-            self.predicate_cache_records.set(v);
-        }
-    }
-
-    fn project_batch(&self, batch: &RecordBatch) -> Result<RecordBatch> {
-        let mut batch = self.projector.project_batch(batch)?;
-        if self.replace_schema {
-            // Ensure the output batch has the expected schema.
-            // This handles things like schema level and field level metadata, which may not be present
-            // in the physical file schema.
-            // It is also possible for nullability to differ; some writers create files with
-            // OPTIONAL fields even when there are no nulls in the data.
-            // In these cases it may make sense for the logical schema to be `NOT NULL`.
-            // RecordBatch::try_new_with_options checks that if the schema is NOT NULL
-            // the array cannot contain nulls, amongst other checks.
-            let (_stream_schema, arrays, num_rows) = batch.into_parts();
-            let options = RecordBatchOptions::new().with_row_count(Some(num_rows));
-            batch = RecordBatch::try_new_with_options(
-                Arc::clone(&self.output_schema),
-                arrays,
-                &options,
-            )?;
-        }
-        Ok(batch)
-    }
 }
 
 type ConstantColumns = HashMap<String, ScalarValue>;

--- a/datafusion/datasource-parquet/src/opener.rs
+++ b/datafusion/datasource-parquet/src/opener.rs
@@ -19,7 +19,9 @@
 
 use crate::access_plan::PreparedAccessPlan;
 use crate::page_filter::PagePruningAccessPlanFilter;
-use crate::row_filter::{self, ParquetReadPlan, build_projection_read_plan};
+use crate::row_filter::{
+    ParquetReadPlan, RowFilterGenerator, build_projection_read_plan,
+};
 use crate::row_group_filter::{BloomFilterStatistics, RowGroupAccessPlanFilter};
 use crate::{
     ParquetAccessPlan, ParquetFileMetrics, ParquetFileReaderFactory,
@@ -69,7 +71,7 @@ use parquet::DecodeResult;
 use parquet::arrow::ParquetRecordBatchStreamBuilder;
 use parquet::arrow::arrow_reader::metrics::ArrowReaderMetrics;
 use parquet::arrow::arrow_reader::{
-    ArrowReaderMetadata, ArrowReaderOptions, RowFilter, RowSelectionPolicy,
+    ArrowReaderMetadata, ArrowReaderOptions, RowSelectionPolicy,
 };
 use parquet::arrow::async_reader::AsyncFileReader;
 use parquet::arrow::parquet_column;
@@ -1120,8 +1122,17 @@ impl RowGroupsPrunedParquetOpen {
         );
 
         let (decoder, pending_decoders, remaining_limit) = {
-            let mut row_filter_generator =
-                RowFilterGenerator::new(&prepared, file_metadata.as_ref());
+            let pushdown_predicate = prepared
+                .pushdown_filters
+                .then_some(prepared.predicate.as_ref())
+                .flatten();
+            let mut row_filter_generator = RowFilterGenerator::new(
+                pushdown_predicate,
+                &prepared.physical_file_schema,
+                file_metadata.as_ref(),
+                prepared.reorder_predicates,
+                &prepared.file_metrics,
+            );
 
             // Split into consecutive runs of row groups that share the same filter
             // requirement. Fully matched row groups skip the RowFilter; others need it.
@@ -1226,70 +1237,6 @@ impl RowGroupsPrunedParquetOpen {
             .boxed())
         } else {
             Ok(stream.boxed())
-        }
-    }
-}
-
-/// Builds row filters for decoder runs.
-///
-/// A [`RowFilter`] must be owned by a decoder, so scans split across multiple
-/// decoder runs need a fresh filter for each run that evaluates row predicates.
-struct RowFilterGenerator<'a> {
-    predicate: Option<&'a Arc<dyn PhysicalExpr>>,
-    physical_file_schema: &'a SchemaRef,
-    file_metadata: &'a ParquetMetaData,
-    reorder_predicates: bool,
-    file_metrics: &'a ParquetFileMetrics,
-    first_row_filter: Option<RowFilter>,
-}
-
-impl<'a> RowFilterGenerator<'a> {
-    fn new(
-        prepared: &'a PreparedParquetOpen,
-        file_metadata: &'a ParquetMetaData,
-    ) -> Self {
-        let predicate = prepared
-            .pushdown_filters
-            .then_some(prepared.predicate.as_ref())
-            .flatten();
-
-        let mut generator = Self {
-            predicate,
-            physical_file_schema: &prepared.physical_file_schema,
-            file_metadata,
-            reorder_predicates: prepared.reorder_predicates,
-            file_metrics: &prepared.file_metrics,
-            first_row_filter: None,
-        };
-        generator.first_row_filter = generator.build_row_filter();
-        generator
-    }
-
-    fn has_row_filter(&self) -> bool {
-        self.first_row_filter.is_some()
-    }
-
-    fn next_filter(&mut self) -> Option<RowFilter> {
-        self.first_row_filter
-            .take()
-            .or_else(|| self.build_row_filter())
-    }
-
-    fn build_row_filter(&self) -> Option<RowFilter> {
-        let predicate = self.predicate?;
-        match row_filter::build_row_filter(
-            predicate,
-            self.physical_file_schema,
-            self.file_metadata,
-            self.reorder_predicates,
-            self.file_metrics,
-        ) {
-            Ok(Some(filter)) => Some(filter),
-            Ok(None) => None,
-            Err(e) => {
-                debug!("Ignoring error building row filter for '{predicate:?}': {e}");
-                None
-            }
         }
     }
 }

--- a/datafusion/datasource-parquet/src/opener.rs
+++ b/datafusion/datasource-parquet/src/opener.rs
@@ -19,9 +19,8 @@
 
 use crate::access_plan::PreparedAccessPlan;
 use crate::page_filter::PagePruningAccessPlanFilter;
-use crate::row_filter::{
-    ParquetReadPlan, RowFilterGenerator, build_projection_read_plan,
-};
+use crate::push_decoder::DecoderBuilderConfig;
+use crate::row_filter::{RowFilterGenerator, build_projection_read_plan};
 use crate::row_group_filter::{BloomFilterStatistics, RowGroupAccessPlanFilter};
 use crate::{
     ParquetAccessPlan, ParquetFileMetrics, ParquetFileReaderFactory,
@@ -70,12 +69,10 @@ use log::debug;
 use parquet::DecodeResult;
 use parquet::arrow::ParquetRecordBatchStreamBuilder;
 use parquet::arrow::arrow_reader::metrics::ArrowReaderMetrics;
-use parquet::arrow::arrow_reader::{
-    ArrowReaderMetadata, ArrowReaderOptions, RowSelectionPolicy,
-};
+use parquet::arrow::arrow_reader::{ArrowReaderMetadata, ArrowReaderOptions};
 use parquet::arrow::async_reader::AsyncFileReader;
 use parquet::arrow::parquet_column;
-use parquet::arrow::push_decoder::{ParquetPushDecoder, ParquetPushDecoderBuilder};
+use parquet::arrow::push_decoder::ParquetPushDecoder;
 use parquet::basic::Type;
 use parquet::bloom_filter::Sbbf;
 use parquet::file::metadata::{
@@ -1163,11 +1160,8 @@ impl RowGroupsPrunedParquetOpen {
                     file_metadata.as_ref(),
                     prepared.reverse_row_groups,
                 )?;
-                let mut builder = build_decoder_builder(
-                    prepared_access_plan,
-                    reader_metadata.clone(),
-                    &decoder_config,
-                );
+                let mut builder =
+                    decoder_config.build(prepared_access_plan, reader_metadata.clone());
                 if run.needs_filter {
                     if let Some(row_filter) = row_filter_generator.next_filter() {
                         builder = builder.with_row_filter(row_filter);
@@ -1252,36 +1246,6 @@ fn prepare_access_plan(
         prepared_access_plan = prepared_access_plan.reverse(file_metadata)?;
     }
     Ok(prepared_access_plan)
-}
-
-struct DecoderBuilderConfig<'a> {
-    read_plan: &'a ParquetReadPlan,
-    batch_size: usize,
-    arrow_reader_metrics: &'a ArrowReaderMetrics,
-    force_filter_selections: bool,
-    decoder_limit: Option<usize>,
-}
-
-fn build_decoder_builder(
-    prepared_access_plan: PreparedAccessPlan,
-    metadata: ArrowReaderMetadata,
-    config: &DecoderBuilderConfig<'_>,
-) -> ParquetPushDecoderBuilder {
-    let mut builder = ParquetPushDecoderBuilder::new_with_metadata(metadata)
-        .with_projection(config.read_plan.projection_mask.clone())
-        .with_batch_size(config.batch_size)
-        .with_metrics(config.arrow_reader_metrics.clone());
-    if config.force_filter_selections {
-        builder = builder.with_row_selection_policy(RowSelectionPolicy::Selectors);
-    }
-    if let Some(row_selection) = prepared_access_plan.row_selection {
-        builder = builder.with_row_selection(row_selection);
-    }
-    builder = builder.with_row_groups(prepared_access_plan.row_group_indexes);
-    if let Some(limit) = config.decoder_limit {
-        builder = builder.with_limit(limit);
-    }
-    builder
 }
 
 /// State for a stream that decodes a single Parquet file using a push-based decoder.

--- a/datafusion/datasource-parquet/src/push_decoder.rs
+++ b/datafusion/datasource-parquet/src/push_decoder.rs
@@ -1,0 +1,73 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Push-based Parquet decoder setup.
+//!
+//! This module is responsible for configuring [`ParquetPushDecoderBuilder`]
+//! instances. The opener uses one [`DecoderBuilderConfig`] per file scan and
+//! applies it to every decoder run (a scan may be split into multiple runs
+//! when, for example, fully matched row groups can skip the row filter).
+
+use parquet::arrow::arrow_reader::metrics::ArrowReaderMetrics;
+use parquet::arrow::arrow_reader::{ArrowReaderMetadata, RowSelectionPolicy};
+use parquet::arrow::push_decoder::ParquetPushDecoderBuilder;
+
+use crate::access_plan::PreparedAccessPlan;
+use crate::row_filter::ParquetReadPlan;
+
+/// Shared options applied to every [`ParquetPushDecoderBuilder`] in a file scan.
+///
+/// A single scan may produce multiple decoders (for example, when fully matched
+/// row groups split the scan into consecutive runs with different filter
+/// requirements). All decoders in that scan share the same projection, batch
+/// size, metrics sink, and selection policy.
+pub(crate) struct DecoderBuilderConfig<'a> {
+    pub(crate) read_plan: &'a ParquetReadPlan,
+    pub(crate) batch_size: usize,
+    pub(crate) arrow_reader_metrics: &'a ArrowReaderMetrics,
+    pub(crate) force_filter_selections: bool,
+    pub(crate) decoder_limit: Option<usize>,
+}
+
+impl DecoderBuilderConfig<'_> {
+    /// Build a [`ParquetPushDecoderBuilder`] for a single decoder run.
+    ///
+    /// The caller is expected to attach the run-specific
+    /// [`RowFilter`](parquet::arrow::arrow_reader::RowFilter) and predicate
+    /// cache size on the returned builder.
+    pub(crate) fn build(
+        &self,
+        prepared_access_plan: PreparedAccessPlan,
+        metadata: ArrowReaderMetadata,
+    ) -> ParquetPushDecoderBuilder {
+        let mut builder = ParquetPushDecoderBuilder::new_with_metadata(metadata)
+            .with_projection(self.read_plan.projection_mask.clone())
+            .with_batch_size(self.batch_size)
+            .with_metrics(self.arrow_reader_metrics.clone());
+        if self.force_filter_selections {
+            builder = builder.with_row_selection_policy(RowSelectionPolicy::Selectors);
+        }
+        if let Some(row_selection) = prepared_access_plan.row_selection {
+            builder = builder.with_row_selection(row_selection);
+        }
+        builder = builder.with_row_groups(prepared_access_plan.row_group_indexes);
+        if let Some(limit) = self.decoder_limit {
+            builder = builder.with_limit(limit);
+        }
+        builder
+    }
+}

--- a/datafusion/datasource-parquet/src/push_decoder.rs
+++ b/datafusion/datasource-parquet/src/push_decoder.rs
@@ -15,16 +15,38 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! Push-based Parquet decoder setup.
+//! Push-based Parquet decoder setup and stream driver.
 //!
-//! This module is responsible for configuring [`ParquetPushDecoderBuilder`]
-//! instances. The opener uses one [`DecoderBuilderConfig`] per file scan and
-//! applies it to every decoder run (a scan may be split into multiple runs
-//! when, for example, fully matched row groups can skip the row filter).
+//! This module owns the push-decoder lifecycle:
+//!
+//! - [`DecoderBuilderConfig`] holds the shared options applied to every
+//!   [`ParquetPushDecoderBuilder`] in a file scan, exposing a single `build`
+//!   entry point per decoder run.
+//! - [`PushDecoderStreamState`] is the per-file stream driver that polls one
+//!   or more decoders to completion, yielding projected [`RecordBatch`]es.
+//!   A scan can produce multiple decoders (for example, when fully matched
+//!   row groups split it into runs with different filter requirements); the
+//!   state machine drains them in order so the output is contiguous.
+//!
+//! The opener constructs both halves and hands the state off to
+//! [`PushDecoderStreamState::into_stream`] for consumption.
 
+use std::collections::VecDeque;
+use std::sync::Arc;
+
+use arrow::array::{RecordBatch, RecordBatchOptions};
+use arrow::datatypes::Schema;
+use futures::StreamExt;
+use futures::stream::BoxStream;
+use parquet::DecodeResult;
 use parquet::arrow::arrow_reader::metrics::ArrowReaderMetrics;
 use parquet::arrow::arrow_reader::{ArrowReaderMetadata, RowSelectionPolicy};
-use parquet::arrow::push_decoder::ParquetPushDecoderBuilder;
+use parquet::arrow::async_reader::AsyncFileReader;
+use parquet::arrow::push_decoder::{ParquetPushDecoder, ParquetPushDecoderBuilder};
+
+use datafusion_common::{DataFusionError, Result};
+use datafusion_physical_expr::projection::Projector;
+use datafusion_physical_plan::metrics::{BaselineMetrics, Gauge};
 
 use crate::access_plan::PreparedAccessPlan;
 use crate::row_filter::ParquetReadPlan;
@@ -69,5 +91,149 @@ impl DecoderBuilderConfig<'_> {
             builder = builder.with_limit(limit);
         }
         builder
+    }
+}
+
+/// State for a stream that decodes a single Parquet file using a push-based decoder.
+///
+/// The [`transition`](Self::transition) method drives the decoder in a loop: it requests
+/// byte ranges from the [`AsyncFileReader`], pushes the fetched data into the
+/// [`ParquetPushDecoder`], and yields projected [`RecordBatch`]es until the file is
+/// fully consumed.
+pub(crate) struct PushDecoderStreamState {
+    pub(crate) decoder: ParquetPushDecoder,
+    /// Additional decoders to process after the current one finishes.
+    /// Used when fully matched row groups split the scan into consecutive
+    /// runs with different filter configurations, maintaining original order.
+    pub(crate) pending_decoders: VecDeque<ParquetPushDecoder>,
+    /// Global remaining row limit across all decoder runs.
+    ///
+    /// Decoder-local limits are only safe for single-run scans. When the scan
+    /// is split across multiple decoders, the combined stream limit is enforced
+    /// here instead.
+    pub(crate) remaining_limit: Option<usize>,
+    pub(crate) reader: Box<dyn AsyncFileReader>,
+    pub(crate) projector: Projector,
+    pub(crate) output_schema: Arc<Schema>,
+    pub(crate) replace_schema: bool,
+    pub(crate) arrow_reader_metrics: ArrowReaderMetrics,
+    pub(crate) predicate_cache_inner_records: Gauge,
+    pub(crate) predicate_cache_records: Gauge,
+    pub(crate) baseline_metrics: BaselineMetrics,
+}
+
+impl PushDecoderStreamState {
+    /// Drive the state machine to completion as a [`Stream`] of record batches.
+    ///
+    /// The returned stream is fused and boxed so the caller can wrap it (for
+    /// example, with an early-stopping adapter) without naming the unfold type.
+    pub(crate) fn into_stream(self) -> BoxStream<'static, Result<RecordBatch>> {
+        futures::stream::unfold(self, |state| async move { state.transition().await })
+            .fuse()
+            .boxed()
+    }
+
+    /// Advances the decoder state machine until the next [`RecordBatch`] is
+    /// produced, the file is fully consumed, or an error occurs.
+    ///
+    /// On each iteration the decoder is polled via [`ParquetPushDecoder::try_decode`]:
+    /// - [`NeedsData`](DecodeResult::NeedsData) – the requested byte ranges are
+    ///   fetched from the [`AsyncFileReader`] and fed back into the decoder.
+    /// - [`Data`](DecodeResult::Data) – a decoded batch is projected and returned.
+    /// - [`Finished`](DecodeResult::Finished) – signals end-of-stream (`None`).
+    ///
+    /// Takes `self` by value (rather than `&mut self`) so the generated future
+    /// owns the state directly. This avoids a Stacked Borrows violation under
+    /// miri where `&mut self` creates a single opaque borrow that conflicts
+    /// with `unfold`'s ownership across yield points.
+    async fn transition(mut self) -> Option<(Result<RecordBatch>, Self)> {
+        loop {
+            if self.remaining_limit == Some(0) {
+                return None;
+            }
+            match self.decoder.try_decode() {
+                Ok(DecodeResult::NeedsData(ranges)) => {
+                    let data = self
+                        .reader
+                        .get_byte_ranges(ranges.clone())
+                        .await
+                        .map_err(DataFusionError::from);
+                    match data {
+                        Ok(data) => {
+                            if let Err(e) = self.decoder.push_ranges(ranges, data) {
+                                return Some((Err(DataFusionError::from(e)), self));
+                            }
+                        }
+                        Err(e) => return Some((Err(e), self)),
+                    }
+                }
+                Ok(DecodeResult::Data(batch)) => {
+                    let batch = if let Some(remaining_limit) = self.remaining_limit {
+                        if batch.num_rows() > remaining_limit {
+                            self.remaining_limit = Some(0);
+                            batch.slice(0, remaining_limit)
+                        } else {
+                            self.remaining_limit =
+                                Some(remaining_limit - batch.num_rows());
+                            batch
+                        }
+                    } else {
+                        batch
+                    };
+                    let mut timer = self.baseline_metrics.elapsed_compute().timer();
+                    self.copy_arrow_reader_metrics();
+                    let result = self.project_batch(&batch);
+                    timer.stop();
+                    // Release the borrow on baseline_metrics before moving self
+                    drop(timer);
+                    return Some((result, self));
+                }
+                Ok(DecodeResult::Finished) => {
+                    // If there are pending decoders (e.g. for consecutive runs
+                    // with different filter configurations), switch to the next.
+                    if let Some(next) = self.pending_decoders.pop_front() {
+                        self.decoder = next;
+                        continue;
+                    }
+                    return None;
+                }
+                Err(e) => {
+                    return Some((Err(DataFusionError::from(e)), self));
+                }
+            }
+        }
+    }
+
+    /// Copies metrics from ArrowReaderMetrics (the metrics collected by the
+    /// arrow-rs parquet reader) to the parquet file metrics for DataFusion
+    fn copy_arrow_reader_metrics(&self) {
+        if let Some(v) = self.arrow_reader_metrics.records_read_from_inner() {
+            self.predicate_cache_inner_records.set(v);
+        }
+        if let Some(v) = self.arrow_reader_metrics.records_read_from_cache() {
+            self.predicate_cache_records.set(v);
+        }
+    }
+
+    fn project_batch(&self, batch: &RecordBatch) -> Result<RecordBatch> {
+        let mut batch = self.projector.project_batch(batch)?;
+        if self.replace_schema {
+            // Ensure the output batch has the expected schema.
+            // This handles things like schema level and field level metadata, which may not be present
+            // in the physical file schema.
+            // It is also possible for nullability to differ; some writers create files with
+            // OPTIONAL fields even when there are no nulls in the data.
+            // In these cases it may make sense for the logical schema to be `NOT NULL`.
+            // RecordBatch::try_new_with_options checks that if the schema is NOT NULL
+            // the array cannot contain nulls, amongst other checks.
+            let (_stream_schema, arrays, num_rows) = batch.into_parts();
+            let options = RecordBatchOptions::new().with_row_count(Some(num_rows));
+            batch = RecordBatch::try_new_with_options(
+                Arc::clone(&self.output_schema),
+                arrays,
+                &options,
+            )?;
+        }
+        Ok(batch)
     }
 }

--- a/datafusion/datasource-parquet/src/row_filter.rs
+++ b/datafusion/datasource-parquet/src/row_filter.rs
@@ -1082,6 +1082,70 @@ pub fn build_row_filter(
         .map(|filters| Some(RowFilter::new(filters)))
 }
 
+/// Builds row filters for decoder runs.
+///
+/// A [`RowFilter`] must be owned by a decoder, so scans split across multiple
+/// decoder runs need a fresh filter for each run that evaluates row predicates.
+/// The first filter is built eagerly during construction so callers can cheaply
+/// query [`has_row_filter`](Self::has_row_filter) before splitting the scan.
+pub(crate) struct RowFilterGenerator<'a> {
+    predicate: Option<&'a Arc<dyn PhysicalExpr>>,
+    physical_file_schema: &'a SchemaRef,
+    file_metadata: &'a ParquetMetaData,
+    reorder_predicates: bool,
+    file_metrics: &'a ParquetFileMetrics,
+    first_row_filter: Option<RowFilter>,
+}
+
+impl<'a> RowFilterGenerator<'a> {
+    pub(crate) fn new(
+        predicate: Option<&'a Arc<dyn PhysicalExpr>>,
+        physical_file_schema: &'a SchemaRef,
+        file_metadata: &'a ParquetMetaData,
+        reorder_predicates: bool,
+        file_metrics: &'a ParquetFileMetrics,
+    ) -> Self {
+        let mut generator = Self {
+            predicate,
+            physical_file_schema,
+            file_metadata,
+            reorder_predicates,
+            file_metrics,
+            first_row_filter: None,
+        };
+        generator.first_row_filter = generator.build();
+        generator
+    }
+
+    pub(crate) fn has_row_filter(&self) -> bool {
+        self.first_row_filter.is_some()
+    }
+
+    pub(crate) fn next_filter(&mut self) -> Option<RowFilter> {
+        self.first_row_filter.take().or_else(|| self.build())
+    }
+
+    fn build(&self) -> Option<RowFilter> {
+        let predicate = self.predicate?;
+        match build_row_filter(
+            predicate,
+            self.physical_file_schema,
+            self.file_metadata,
+            self.reorder_predicates,
+            self.file_metrics,
+        ) {
+            Ok(Some(filter)) => Some(filter),
+            Ok(None) => None,
+            Err(e) => {
+                log::debug!(
+                    "Ignoring error building row filter for '{predicate:?}': {e}"
+                );
+                None
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;


### PR DESCRIPTION
Stacked on top of your #22191. Three small commits that move the pieces that don't depend on opener-internal types out of `opener.rs`, so the file gets closer to pure state-machine orchestration.

## Summary

1. **Move `RowFilterGenerator` to `row_filter.rs`.** Decouples it from `PreparedParquetOpen` — it now takes its inputs directly (predicate, schema, metadata, reorder flag, metrics), so it lives next to the `build_row_filter` it wraps. (I considered a literal `impl From<&PreparedParquetOpen>` per Adrian's suggestion, but the constructor also needs `file_metadata` which is a sibling of `prepared` rather than a field on it, so a generic `new(...)` was the cleanest decoupling. Happy to fold into a `From<(&PreparedParquetOpen, &ParquetMetaData)>` tuple impl if you'd prefer.)
2. **Extract `DecoderBuilderConfig` into a new `push_decoder.rs` module.** Same struct + fields; the free `build_decoder_builder` becomes a `.build(prepared_access_plan, metadata)` method on the config, which reads more naturally at the call site.
3. **Move `PushDecoderStreamState` into `push_decoder.rs`.** Co-locates the per-file stream driver with the builder configuration it consumes. Adds `into_stream(self) -> BoxStream<...>` so the opener doesn't need to name the unfold/fuse type — it just hands off the state and gets back a boxed stream. Drops the now-unused `parquet::DecodeResult`, `ParquetPushDecoder`, `Projector`, `Gauge`, `DataFusionError`, etc. imports from `opener.rs`.

After this, `push_decoder.rs` owns the full push-decoder lifecycle (builder setup + stream driving), and `build_stream` in `opener.rs` reads as orchestration: prepare access plans, build decoders, hand off to the stream, optionally wrap in `EarlyStoppingStream`.

The commits are stacked one-move-per-commit so each is reviewable independently.

## No behavior change

Every move is pure code motion; no semantics change. The tests called out in #22191's body still pass:

- `cargo fmt --all --check` — clean
- `cargo clippy -p datafusion-datasource-parquet --all-targets --all-features -- -D warnings` — clean
- `cargo test -p datafusion-datasource-parquet --lib fully_matched` — 5/5 pass
- `cargo test -p datafusion-datasource-parquet --lib test_page_pruning_predicate_respects_enable_page_index` — 1/1 pass

(Full `--lib` run has 16 unrelated failures from a missing `parquet-testing` submodule fixture in my worktree — same failures on the base commit.)

## Are there any user-facing changes?

No. All moved items are `pub(crate)`. The public `PagePruningAccessPlanFilter::prune_plan_with_page_index` API restored in #22191 is untouched.